### PR TITLE
Fixed failed_pod query and updated CSV description 

### DIFF
--- a/config/manifests/bases/analytics-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/analytics-operator.clusterserviceversion.yaml
@@ -33,18 +33,23 @@ spec:
     may introduce a change that is **NOT** backward-compatible with the previous version.
     Thus, to upgrade the operator, uninstall the already installed version completely
     (including CRDs) and install the new version.\n\n### Installtion Steps for the
-    Anomaly Engine\nOnce you install the Observability Analytics operator, wait until
-    you see the operator in the **Installed Operator** list. Click on the Operator
-    name and go to Operator details.\n\nHere you should see a tab called **Anomaly
-    Engine**. Click on it, and then click on the **Create AnomalyEngine** button,
-    which will redirect you to a form where you need to provide the required inputs
-    for the Anomaly Engine. Once successfully created, you should see a cronjob in
-    the given namespace. This cronjob will identify anomalies and store them into
+    Anomaly Engine\n Create namespace if you would like to install this operator into
+    separate namespace (You can utilize existing namespace as well). ```bash kubectl
+    create ns <Namespace> ``` Install the Observability Analytics operator to specific
+    `<Namespace>`, wait until you see the operator in the **Installed Operator** list.
+    Click on the Operator name and go to Operator details.\n\nHere you should see
+    a tab called **Anomaly Engine**. Click on it, and then click on the **Create AnomalyEngine**
+    button, which will redirect you to a form where you need to provide the required
+    inputs for the Anomaly Engine. Once successfully created, you should see a cronjob
+    in the given namespace. This cronjob will identify anomalies and store them into
     **anomalydata**.\n\n### How to See Anomaly Data Captured by Anomaly Engine?\nWe
-    are storing anomaly data into CR. You can check detected anomalies using the following
-    command from your terminal. (As of now, we don't have any UI to showcase this
-    data in the cluster)\n\n```bash\nkubectl get anomalydata -n <Namespace>\nkubectl
-    describe anomalydata <NAME of the anomalydata> -n <Namespace> \n```\n\n### Documentation\nDocumentation
+    are storing anomaly data into CR.\n ####Option 1:Through `kubectl`` command\nYou
+    can check detected anomalies using the following command from your terminal. \n\n```bash\nkubectl
+    get anomalydata -n <Namespace>\nkubectl describe anomalydata <NAME of the anomalydata>
+    -n <Namespace> \n```\n #### Option 2: From Installed Operator UI Go to installed
+    operator and select **Observability Analytics** operator, now go to **Anomaly
+    Data** tab where you can able to see the detected anomaly, click on specific anomaly
+    and you should be able to see details of the same. ### Documentation\nDocumentation
     around how to test Operator codebase as a developer can be found [here](https://github.com/openshift/analytics-operator#readme)\n\n###
     Contributing\nYou can contribute by:\n  * Raising [issues](https://github.com/openshift/analytics-operator/issues)\n
     \   related to observability-analytics-operator\n  * Fixing issues by opening

--- a/config/samples/observability-analytics_v1alpha1_anomalyengine.yaml
+++ b/config/samples/observability-analytics_v1alpha1_anomalyengine.yaml
@@ -16,7 +16,7 @@ spec:
   anomalyqueryconfiguration: |
     etcd_objects_all:
       method: percentage_change
-      query: max(apiserver_storage_objects{resource!~"certificatesigningrequests.certificates.k8s.io|installplans.operators.coreos.com|operators.operators.coreos.com|subscriptions.operators.coreos.com|anomalydata.observability-analytics.redhat.com"}) by (resource)
+      query: max(apiserver_storage_objects{resource!~"certificatesigningrequests.certificates.k8s.io|installplans.operators.coreos.com|operators.operators.coreos.com|subscriptions.operators.coreos.com|anomalydata.observability-analytics.redhat.com|anomalyengines.observability-analytics.redhat.com"}) by (resource)
       step: 5  # minutes
       percentage_change: 60  # percentage
       period_range: 120  # minutes
@@ -51,7 +51,7 @@ spec:
   cronjobconfig:
     name: "osa-anomaly-detection"
     schedule: "*/5 * * * *"
-    anomalyqueries: "etcd_objects_all,workload_memory_usage_bytes,workload_cpu_usage_cores,rest_client_requests_total,scheduler_pending_pods"
+    anomalyqueries: "etcd_objects_all,failed_pods,workload_memory_usage_bytes,workload_cpu_usage_cores,rest_client_requests_total"
     resource:
       cpurequest: "128m"
       memoryrequest: "256Mi"

--- a/config/samples/observability-analytics_v1alpha1_anomalyengine.yaml
+++ b/config/samples/observability-analytics_v1alpha1_anomalyengine.yaml
@@ -21,6 +21,12 @@ spec:
       percentage_change: 60  # percentage
       period_range: 120  # minutes
       have_multi_result_data: True
+    failed_pods:
+      method: min_max
+      query: count(kube_pod_status_phase{phase!~"Succeeded|Pending|Running|Unknown"}) by (phase, namespace)
+      min: 0
+      max: 10
+      have_multi_result_data: True
     workload_memory_usage_bytes:
       method: percentage_change
       query: sum(container_memory_working_set_bytes{namespace!~"openshift-.+",pod!="",container=""})
@@ -42,11 +48,6 @@ spec:
       percentage_change: 60  # percentage
       period_range: 120  # minutes
       have_multi_result_data: False
-    scheduler_pending_pods:
-      method: min_max
-      query: sum(scheduler_pending_pods{queue=~"backoff|unschedulable"}) by (queue)
-      min: 0
-      max: 10
   cronjobconfig:
     name: "osa-anomaly-detection"
     schedule: "*/5 * * * *"

--- a/tests/run-e2e.sh
+++ b/tests/run-e2e.sh
@@ -348,7 +348,7 @@ test_configmap_anomaly(){
     info "existing_configmap_count : $existing_configmap_count"
 
     # calculate required configmaps that needs to ingest
-    required_configmaps=$(($existing_configmap_count*65/100))
+    required_configmaps=$(($existing_configmap_count*110/100))
     info "required_configmaps : $required_configmaps"
 
     ingest_configmaps $required_configmaps


### PR DESCRIPTION
PR contains following changes

- ClusterServiceVersion updated description 
- Fixed query to get failed pod, updated metric as well as replaced `sum` with `count`
-  Ingesting more `configmaps` for e2e test case. 

Signed-off-by: Raj Zalavadia [rzalavad@redhat.com](mailto:rzalavad@redhat.com)